### PR TITLE
Use claude-code native installer

### DIFF
--- a/homeadditions/.bashrc.d/claude-code.sh
+++ b/homeadditions/.bashrc.d/claude-code.sh
@@ -1,0 +1,3 @@
+# ddev-generated
+# claude-code native installer's installation directory is not user-configurable, so add it to PATH.
+export PATH="$HOME/.local/bin:$PATH"

--- a/install.yaml
+++ b/install.yaml
@@ -13,3 +13,4 @@ project_files:
   - config.claude-code.yaml
   - claude-code/.claude.json
   - claude-code/.gitignore
+  - homeadditions/.bashrc.d/claude-code.sh

--- a/web-build/Dockerfile.claude-code
+++ b/web-build/Dockerfile.claude-code
@@ -1,5 +1,11 @@
 #ddev-generated
 
-RUN npm install -g @anthropic-ai/claude-code
+# Use the native installer for Claude Code.
+# Claude Code needs to be installed to the user's local/bin, not root's.
+USER $username
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
+# Install GitLab support as root.
+USER root
+RUN apt-get update
 RUN curl -sSL "https://raw.githubusercontent.com/upciti/wakemeops/main/assets/install_repository" | bash && apt install -y glab


### PR DESCRIPTION
Claude code has switched to a native installer. Fixes https://github.com/FreelyGive/ddev-claude-code/issues/7

* The installation path of the claude-code installer is .local/bin and currently cannot be customized, so the path is set via homeadditions.