### PR TITLE
Set terminal window title to DDEV project name for claude command

### DIFF
--- a/commands/web/claude
+++ b/commands/web/claude
@@ -7,4 +7,21 @@
 
 set -e
 
-claude $@
+# Set the terminal tab/window title to the DDEV project name so multiple
+# concurrent Claude Code sessions across projects are distinguishable.
+set_tab_title() {
+    printf '\033]0;%s - %s\007' "${DDEV_SITENAME}" "${1:-Claude Code}"
+}
+# Clear the title on exit and let the host shell's prompt re-set it. We can't
+# read the host's TERM_PROGRAM from inside the container, so don't guess at it.
+restore_tab_title() {
+    printf '\033]0;\007'
+}
+
+set_tab_title "Claude Code"
+trap restore_tab_title EXIT
+
+# Disable Claude Code's own terminal-title management so it doesn't overwrite
+# the project-prefixed title set above.
+export CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1
+claude "$@"


### PR DESCRIPTION
## What

Wraps the `ddev claude` command so it sets the terminal tab/window title to the DDEV project name (`<sitename> - Claude Code`), making concurrent Claude Code sessions across multiple DDEV projects distinguishable at a glance.

Inspired by [trebormc/ddev-claude-code](https://github.com/trebormc/ddev-claude-code)'s tty title wrapper.

## How

- Adds `set_tab_title` / `restore_tab_title` helpers using OSC escape sequences (`\033]0;…\007`).
- Sets the title before launching `claude` and clears it on exit via a `trap`.
- Exports `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` so Claude Code doesn't overwrite the project-prefixed title.

## Notes

Kept as a **web** command rather than a host command. Our `claude` runs inside the web container, and DDEV runs the web command via `docker exec -it` with a pty, so the OSC title sequences travel back to the host terminal. Unlike the reference (which uses a dedicated container + host command), we don't have a host-side `TERM_PROGRAM` to restore — so the exit handler simply clears the title and lets the host shell's prompt re-set it, rather than clobbering it with a literal `"Terminal"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)