### PR TITLE
Add automated tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐞 Bug report or Support Request
+description: Create a report to help us improve.
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
+      options:
+        - label: I am using the latest stable version of DDEV
+          required: true
+        - label: I am using the latest stable version of this add-on
+          required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Specific steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run `...`
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Screenshots? Anything that will give us more context about your issue!
+
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project.
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search existing issues to see if one already exists for your request.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Clearly and concisely describe the problem. (Ex. I'm always frustrated when...)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your solution
+      description: Clearly and concisely describe what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives
+      description: Clearly and concisely describe any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## The Issue
+
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
+## Manual Testing Instructions
+
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
+```bash
+ddev add-on get https://github.com/FreelyGive/ddev-claude-code/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev restart
+```
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: tests
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - "**.md"
+
+  schedule:
+    - cron: '25 08 * * *'
+
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: Debug with tmate
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        ddev_version: [stable, HEAD]
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+Thanks for contributing to the DDEV Claude Code add-on!
+
+## Prerequisites
+
+- [DDEV](https://ddev.com/) installed and working (the tests create and start a real DDEV project).
+- [Bats](https://bats-core.readthedocs.io/) plus the `bats-assert`, `bats-file`, and `bats-support` helper libraries.
+
+## Installing Bats
+
+### macOS (Homebrew)
+
+```bash
+brew install bats-core bats-assert bats-file bats-support
+```
+
+The tests automatically pick these up from your Homebrew prefix.
+
+### Linux
+
+Install `bats-core` via your package manager (or [from source](https://bats-core.readthedocs.io/en/stable/installation.html)), then install the helper libraries:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install bats
+
+# Helper libraries (clone into a directory on your BATS_LIB_PATH, e.g. /usr/lib/bats)
+sudo git clone https://github.com/bats-core/bats-assert  /usr/lib/bats/bats-assert
+sudo git clone https://github.com/bats-core/bats-file    /usr/lib/bats/bats-file
+sudo git clone https://github.com/bats-core/bats-support /usr/lib/bats/bats-support
+```
+
+The tests look for the helper libraries on `BATS_LIB_PATH`, which defaults to include
+`/usr/lib/bats` and `/usr/local/lib/bats`. If you install them elsewhere, export
+`BATS_LIB_PATH` to point at that location:
+
+```bash
+export BATS_LIB_PATH="/path/to/your/bats/libraries"
+```
+
+## Running the tests
+
+From the add-on root directory:
+
+```bash
+bats ./tests/test.bats --filter-tags '!release'
+```
+
+The `install from directory` test installs the add-on from your local working copy, so it
+reflects your current changes. The `install from release` test installs the published
+release from GitHub, so it's only meaningful in CI — the `--filter-tags '!release'` above
+excludes it while developing locally. (CI runs it on the daily schedule; see below.)
+
+For more verbose output when debugging a failure:
+
+```bash
+bats ./tests/test.bats --filter-tags '!release' --show-output-of-passing-tests --verbose-run --print-output-on-failure
+```
+
+## Continuous integration
+
+The same tests run automatically in GitHub Actions (see
+[`.github/workflows/tests.yml`](.github/workflows/tests.yml)) on pull requests and pushes
+to `main`, against both the `stable` and `HEAD` versions of DDEV.
+
+There is also a daily scheduled run. On pull requests and pushes the `install from
+release` test is skipped (via its `release` tag), so only `install from directory` runs.
+The scheduled run executes the full suite — including `install from release` — which acts
+as a regression check that the latest published release still installs and works against
+current DDEV. This is why a `HEAD` failure can show up on the schedule before it appears
+on any pull request.

--- a/install.yaml
+++ b/install.yaml
@@ -13,3 +13,5 @@ project_files:
   - config.claude-code.yaml
   - claude-code/.claude.json
   - claude-code/.gitignore
+
+ddev_version_constraint: '>= v1.24.3'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+# Bats is a testing framework for Bash
+# Documentation https://bats-core.readthedocs.io/en/stable/
+# Bats libraries documentation https://github.com/ztombol/bats-docs
+
+# For local tests, install bats-core, bats-assert, bats-file, bats-support
+# And run this in the add-on root directory:
+#   bats ./tests/test.bats
+# To exclude release tests:
+#   bats ./tests/test.bats --filter-tags '!release'
+# For debugging:
+#   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
+
+setup() {
+  set -eu -o pipefail
+
+  # When CI is re-run with debug logging (RUNNER_DEBUG=1), make `run` print the
+  # $output of every command on failure. This surfaces the post-start hook log
+  # captured by `run ddev restart`, which is otherwise swallowed on success.
+  [ "${RUNNER_DEBUG:-}" = "1" ] && export BATS_VERBOSE_RUN=1
+
+  # Override this variable for your add-on:
+  export GITHUB_REPO=FreelyGive/ddev-claude-code
+
+  TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  export BATS_LIB_PATH="${BATS_LIB_PATH:-}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats:/usr/local/lib/bats"
+  bats_load_library bats-assert
+  bats_load_library bats-file
+  bats_load_library bats-support
+
+  export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
+  export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  mkdir -p "${HOME}/tmp"
+  export TESTDIR="$(mktemp -d "${HOME}/tmp/${PROJNAME}.XXXXXX")"
+  export DDEV_NONINTERACTIVE=true
+  export DDEV_NO_INSTRUMENTATION=true
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
+  cd "${TESTDIR}"
+  run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site --omit-containers db,ddev-ssh-agent
+  assert_success
+  run ddev start -y
+  assert_success
+}
+
+# DDEV runs post-start hooks non-fatally: a failing hook is logged but the command
+# still exits 0. Assert the preceding command's output reported no failed hook, so a
+# silently-broken hook (the class of bug behind the config-wiring regressions) is
+# caught at the source.
+refute_hook_failure() {
+  refute_output --partial "Task failed"
+}
+
+health_checks() {
+  # The whole point of the add-on: `ddev claude` runs the Claude Code CLI inside the
+  # web container. --version needs no auth or network, so it just proves the binary
+  # is installed and reachable on PATH.
+  run ddev claude --version
+  assert_success
+  assert_output --partial "Claude Code"
+}
+
+# The user's config (API key, settings, MCP servers, auth state) lives in the host
+# project under .ddev/claude-code and is wired into the container so Claude Code reads
+# and writes it live — no restart needed. Verify BOTH directions through Claude's OWN
+# behavior rather than by inspecting symlinks.
+assert_config_round_trips() {
+  # Host -> container: seed an MCP server into the persisted config and confirm Claude,
+  # running in the container, detects it immediately. An MCP entry is a convenient probe
+  # — plain JSON in ~/.claude.json (the file the add-on persists) that `claude mcp get`
+  # reads back. The dummy command never connects, but detection is all we're testing.
+  cat > "${TESTDIR}/.ddev/claude-code/.claude.json" <<'EOF'
+{"mcpServers":{"ddev-host-marker":{"type":"stdio","command":"/bin/true","args":[]}}}
+EOF
+  # `claude mcp get` exits non-zero for an unknown server, so a successful lookup means
+  # Claude Code actually parsed our config.
+  run ddev claude mcp get ddev-host-marker
+  assert_success
+  assert_output --partial "ddev-host-marker"
+  # "User config" scope confirms Claude read it from ~/.claude.json specifically — the
+  # file the add-on symlinks into the container — and not some project-local config.
+  assert_output --partial "User config"
+
+  # Container -> host: write config via `ddev claude` and confirm it lands back in the
+  # host-side file, so interactive setup (auth, etc.) persists into the project. Claude
+  # writes its config atomically, so this also guards against the write replacing the
+  # symlink with a detached regular file.
+  run ddev claude mcp add ddev-claude-marker -s user -- /bin/true
+  assert_success
+  run cat "${TESTDIR}/.ddev/claude-code/.claude.json"
+  assert_success
+  assert_output --partial "ddev-claude-marker"
+}
+
+teardown() {
+  set -eu -o pipefail
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1
+  # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
+  # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    [ -e "${GITHUB_ENV:-}" ] && echo "TESTDIR=${HOME}/tmp/${PROJNAME}" >> "${GITHUB_ENV}"
+  else
+    [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
+  fi
+}
+
+@test "install from directory" {
+  set -eu -o pipefail
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  refute_hook_failure
+  health_checks
+  assert_config_round_trips
+}
+
+# bats test_tags=release
+@test "install from release" {
+  set -eu -o pipefail
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${GITHUB_REPO}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  refute_hook_failure
+  health_checks
+  assert_config_round_trips
+}


### PR DESCRIPTION
## The Issue

- Fixes #10

Automated tests are critical to the trustworthiness of any DDEV add-on. This PR adds a test suite and the standard add-on maintenance scaffolding recommended by the [DDEV add-on maintenance guide](https://ddev.com/blog/ddev-add-on-maintenance-guide/).

## How This PR Solves The Issue

- **`tests/test.bats`** — Bats suite with two tests: `install from directory` (local working copy) and `install from release` (release-tagged, CI/scheduled only). Each installs the add-on, restarts, and asserts:
  - The add-on installs with no failed post-start hooks (`refute_hook_failure` catches the silently-broken-hook class of bug, since DDEV logs hook failures but still exits 0).
  - `ddev claude --version` runs — the binary is installed and on PATH.
  - **Config is handled correctly, verified through Claude's own behavior rather than by inspecting symlinks:**
    - Host → container: a host-seeded MCP server is detected live by `ddev claude mcp get` (no restart needed — the symlink is live).
    - Container → host: a server added via `ddev claude mcp add -s user` round-trips back into the persisted host config (also guards against Claude's atomic write detaching the symlink).
- **`.github/workflows/tests.yml`** — runs the suite on PRs, pushes to `main`, a daily schedule, and manual dispatch, against both `stable` and `HEAD` DDEV via `ddev/github-action-add-on-test@v2`.
- **Hygiene files** — `.gitattributes` (release `export-ignore`), `CONTRIBUTING.md`, issue/PR templates, and `ddev_version_constraint: '>= v1.24.3'` in `install.yaml`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/FreelyGive/ddev-claude-code/tarball/refs/pull/14/head
ddev restart
```

Or run the suite locally (excluding the release test):

```bash
bats ./tests/test.bats --filter-tags '!release'
```

## Automated Testing Overview

This PR introduces the automated tests described above. The `install from directory` test passes locally end-to-end.

## Release/Deployment Notes

`ddev_version_constraint: '>= v1.24.3'` is now enforced at install time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
