### PR TITLE
Document Claude Code authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,71 @@
 # ddev-claude-code <!-- omit in toc -->
 
 ## Claude Code
-Claude Code is installed inside the DDEV container and is accesible using
-`ddev claude`. When you first run, you will be prompted to do this
-interactively. Your configuration will be stored in `.ddev/.claude.json`
-and `.ddev/.claude/`, and will be persisted across restarts.
+Claude Code is installed inside the DDEV container and is run with `ddev claude`.
 
-You can copy in an existing `.ddev/.claude.json`, for example if you want to
-use an existing key, or allowed functions etc.
+### Authenticating
+The first time you run `ddev claude`, Claude Code walks you through its built-in
+guided login. This is the recommended way to authenticate and covers the common
+cases:
+
+- **Claude subscription (Pro/Max)** — choose the subscription option and complete
+  the browser login with your Claude.ai account.
+- **Anthropic Console (pay-as-you-go API billing)** — choose the API option and
+  complete the browser login with your [console.anthropic.com](https://console.anthropic.com)
+  account.
+
+If the container can't open a browser for you, Claude Code prints a URL to open
+yourself and prompts for the code it gives you back.
+
+Your credentials and configuration are stored under `.ddev/claude-code/` (the
+`.claude.json` file and the `.claude/` directory, which holds the login
+credentials in `.claude/.credentials.json`), and persist across restarts and
+rebuilds. You can also copy an existing `.claude.json` / `.claude/` into
+`.ddev/claude-code/` to reuse credentials, settings, or allowed tools from
+another machine.
+
+### API keys, cloud providers and self-hosted endpoints
+For the cases the guided login doesn't cover — a raw API key, Amazon Bedrock,
+Google Vertex AI, or a self-hosted/proxy endpoint — set the relevant environment
+variables for the web container. DDEV reads them from a `.ddev/.env.web` file, so
+create one with the variables for your chosen method:
+
+```shell
+# Anthropic API key (instead of the guided login)
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Amazon Bedrock (AWS credentials must also be available in the container)
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=us-east-1
+AWS_PROFILE=my-profile
+
+# Google Vertex AI (GCP credentials must also be available in the container)
+CLAUDE_CODE_USE_VERTEX=1
+ANTHROPIC_VERTEX_PROJECT_ID=my-project
+CLOUD_ML_REGION=global
+
+# Self-hosted / proxy endpoint (Anthropic API format)
+ANTHROPIC_BASE_URL=https://gateway.example.com
+ANTHROPIC_AUTH_TOKEN=...
+```
+
+These are secrets, so keep the file out of your repo by adding it to your
+project's top-level `.gitignore`:
+
+```shell
+echo '.ddev/.env.web' >> .gitignore
+```
+
+Then `ddev restart` to apply. When these variables are set, Claude Code uses them
+instead of the guided login.
+
+Alternatively, set the variables globally so they apply to every project on your
+machine without any per-project file. This also keeps them out of the repo:
+
+```shell
+ddev config global --web-environment-add="ANTHROPIC_API_KEY=sk-ant-..."
+ddev restart
+```
 
 ## Drupal CLAUDE.md
 For Drupal, we recommend using https://www.drupal.org/project/claude_code. You


### PR DESCRIPTION
## The Issue

- Fixes #3

The README didn't explain how to authenticate Claude Code in the container, including self-hosted/proxy providers.

## How This PR Solves The Issue

Expands the README's Claude Code section to cover authentication:

- **Guided login (recommended)** — running `ddev claude` walks through the built-in interactive login, covering both a **Claude subscription (Pro/Max)** and **Anthropic Console (pay-as-you-go API)**, with the browser-fallback flow noted for headless containers.
- **API keys, cloud providers and self-hosted endpoints** — for cases the guided login doesn't cover, set environment variables for the web container via a `.ddev/.env.web` file, with concrete examples for a raw API key, Amazon Bedrock, Google Vertex AI, and a self-hosted/proxy `ANTHROPIC_BASE_URL` endpoint. Includes the `.gitignore` step to keep secrets out of the repo, plus `ddev config global` as an alternative.
- **Path fix** — corrects the persisted config location to `.ddev/claude-code/` (`.claude.json` and `.claude/`, including the login credentials in `.claude/.credentials.json`).

## Manual Testing Instructions

Documentation only — render the README and follow the authentication steps. The `.ddev/.env.web` behaviour was verified against DDEV v1.25.2 (the web container picks up the variables).

## Automated Testing Overview

No tests needed — README-only change.

## Release/Deployment Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)