### PR TITLE
Add `ddev claude-update` command to update Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,57 @@ ddev config global --web-environment-add="ANTHROPIC_API_KEY=sk-ant-..."
 ddev restart
 ```
 
+## Updating Claude Code
+
+Claude Code is installed into the web container image, so it is pinned to whatever
+version was current when that image was built. It is **not** updated automatically.
+
+This add-on provides `ddev claude-update` to manage updates. On every `ddev start`
+it also runs automatically (in report-only mode) and tells you when a newer version
+is available.
+
+```shell
+# Check whether an update is available and how to apply it.
+ddev claude-update -n
+
+# Update straight away, no prompts.
+ddev claude-update -y
+
+# Prompt to choose how to update (when run in a terminal).
+ddev claude-update
+```
+
+There are two ways to apply an update, and they differ in how long they last:
+
+- **Instant (in the running container).** `ddev claude-update -y` updates Claude
+  Code inside the current container in a few seconds. This is fast, but the change
+  lives only in the running container and is lost the next time the image is
+  rebuilt (for example on `ddev restart --no-cache` or a DDEV upgrade).
+- **Permanent (rebuild the image).** Rebuilding the web image re-runs the installer
+  and bakes in the latest version, so it survives future rebuilds. On DDEV v1.25.0
+  or higher:
+
+  ```shell
+  ddev restart --no-cache
+  ```
+
+  This is slower (it rebuilds the image) but the update persists.
+
+### Updating automatically on start
+
+To always pick up the latest Claude Code instantly whenever a project starts, set
+the `DDEV_CLAUDE_CODE_AUTOUPDATE` environment variable in your **host** shell (the
+update command runs on the host, so a DDEV web-environment variable won't be seen):
+
+```shell
+# Add to your ~/.bashrc, ~/.zshrc, etc.
+export DDEV_CLAUDE_CODE_AUTOUPDATE=1
+```
+
+With this set, the post-start hook applies the instant update on every start
+instead of just reporting it. Remember this is the instant update, so for a version
+that persists across rebuilds you still want `ddev restart --no-cache`.
+
 ## Drupal CLAUDE.md
 For Drupal, we recommend using https://www.drupal.org/project/claude_code. You
 can install by running:

--- a/commands/host/claude-update
+++ b/commands/host/claude-update
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Check for and optionally apply Claude Code updates
+## Usage: claude-update [-y|-n]
+## Example: "ddev claude-update" prompts | "ddev claude-update -y" updates now | "ddev claude-update -n" only reports
+## CanRunGlobally: false
+
+set -eu -o pipefail
+
+# The add-on installs Claude Code with the official installer, which always tracks
+# the "latest" release channel, and `claude update` does the same. Compare against
+# that channel so the check, the in-container update, and a rebuild all agree.
+RELEASE_CHANNEL_URL="https://downloads.claude.ai/claude-code-releases/latest"
+
+# Parse flags:
+#   -y / DDEV_CLAUDE_CODE_AUTOUPDATE  update now, no questions asked
+#   -n                                only report whether an update exists
+#   (nothing)                         prompt; or, with no terminal (e.g. a
+#                                     post-start hook), behave like -n
+mode="prompt"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) mode="yes" ;;
+    -n|--no) mode="no" ;;
+    -h|--help) echo "Usage: ddev claude-update [-y|-n]"; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+if [ "$mode" = "prompt" ] && [ -n "${DDEV_CLAUDE_CODE_AUTOUPDATE:-}" ]; then
+  mode="yes"
+fi
+
+# Highest of two X.Y.Z versions.
+highest_version() {
+  printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1
+}
+
+# Echo the persist command (`ddev restart --no-cache`) when DDEV is new enough to
+# support it (v1.25.0+), otherwise echo nothing.
+nocache_command() {
+  local ddev_ver min="1.25.0"
+  ddev_ver="$(ddev --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)" || true
+  if [ -n "$ddev_ver" ] && [ "$(highest_version "$min" "$ddev_ver")" = "$ddev_ver" ]; then
+    echo "ddev restart --no-cache"
+  fi
+}
+
+# Update Claude Code inside the running web container. This lasts until the next
+# image rebuild. ~/.local/bin is forced onto PATH so the updater doesn't warn
+# about it (the add-on exposes claude via ~/bin instead).
+do_update() {
+  ddev exec 'PATH="$HOME/.local/bin:$PATH" claude update'
+}
+
+# Explain that an in-container update is not permanent, and how to make it so.
+print_persist_note() {
+  local nc
+  nc="$(nocache_command)"
+  echo "This updates the running container only and is lost on the next rebuild."
+  if [ -n "$nc" ]; then
+    echo "To make it permanent, run: ${nc}"
+  else
+    echo "To make it permanent, upgrade to DDEV v1.25.0+ and run 'ddev restart --no-cache'."
+  fi
+}
+
+# The -n / non-interactive report.
+report_only() {
+  local nc
+  nc="$(nocache_command)"
+  echo "A Claude Code update is available (${current} -> ${latest})."
+  echo "  Update now (until next rebuild):  ddev claude-update -y"
+  if [ -n "$nc" ]; then
+    echo "  Update permanently:               ${nc}"
+  else
+    echo "  Update permanently:               upgrade to DDEV v1.25.0+, then 'ddev restart --no-cache'"
+  fi
+}
+
+# Current version inside the web container (leading X.Y.Z of `claude --version`).
+current="$(ddev exec claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)" || true
+if [ -z "$current" ]; then
+  echo "Claude Code is not installed in the web container yet; skipping update check."
+  exit 0
+fi
+
+# Latest published version. Fail soft so a post-start hook never breaks `ddev start`.
+latest="$(curl -fsSL --max-time 5 "$RELEASE_CHANNEL_URL" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' | head -n1)" || true
+if [ -z "$latest" ]; then
+  echo "Could not reach the Claude Code release server; skipping update check."
+  exit 0
+fi
+
+# Already current (or somehow ahead of the published version)? Stay silent in the
+# post-start hook (prompt mode with no terminal) to avoid noise on every start.
+if [ "$current" = "$latest" ] || [ "$(highest_version "$current" "$latest")" = "$current" ]; then
+  if [ "$mode" != "prompt" ] || [ -t 0 ]; then
+    echo "Claude Code is up to date (${current})."
+  fi
+  exit 0
+fi
+
+case "$mode" in
+  yes)
+    echo "Updating Claude Code (${current} -> ${latest})..."
+    do_update
+    echo
+    print_persist_note
+    ;;
+  no)
+    report_only
+    ;;
+  prompt)
+    # No terminal (post-start hook, CI, piped): report and exit, like -n.
+    if [ ! -t 0 ]; then
+      report_only
+      exit 0
+    fi
+    nc="$(nocache_command)"
+    echo "A Claude Code update is available (${current} -> ${latest})."
+    echo
+    echo "  [i] Update now in the running container (fast; lost on next rebuild)"
+    if [ -n "$nc" ]; then
+      echo "  [p] Update permanently by rebuilding the image (${nc})"
+    fi
+    echo "  [c] Cancel"
+    echo
+    read -r -p "Choose [i/p/c]: " choice
+    case "$choice" in
+      i|I)
+        echo "Updating Claude Code (${current} -> ${latest})..."
+        do_update
+        echo
+        print_persist_note
+        ;;
+      p|P)
+        if [ -n "$nc" ]; then
+          echo "Rebuilding to update Claude Code permanently..."
+          exec ${nc}
+        else
+          echo "A permanent update needs DDEV v1.25.0+. Upgrade DDEV, then run 'ddev restart --no-cache'."
+        fi
+        ;;
+      *)
+        echo "Cancelled."
+        ;;
+    esac
+    ;;
+esac

--- a/config.claude-code.yaml
+++ b/config.claude-code.yaml
@@ -4,3 +4,6 @@ hooks:
     - exec: "[[ -f /var/www/html/.ddev/claude-code/.claude.json ]] || echo '{}' > /var/www/html/.ddev/claude-code/.claude.json"
     - exec: "rm ~/.claude.json || true; ln -s /var/www/html/.ddev/claude-code/.claude.json ~/.claude.json"
     - exec: "rm -rf ~/.claude || true; mkdir -p /var/www/html/.ddev/claude-code/.claude && ln -s /var/www/html/.ddev/claude-code/.claude ~/.claude"
+    # Report (or, with DDEV_CLAUDE_CODE_AUTOUPDATE set, apply) any Claude Code update.
+    # Runs on the host so it can read that env var and offer `ddev restart --no-cache`.
+    - exec-host: "ddev claude-update"

--- a/install.yaml
+++ b/install.yaml
@@ -9,6 +9,7 @@ name: claude-code
 project_files:
   - web-build/Dockerfile.claude-code
   - commands/web/claude
+  - commands/host/claude-update
   - config.claude-code.yaml
   - claude-code/.claude.json
   - claude-code/.gitignore

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -116,6 +116,129 @@ teardown() {
   assert_config_round_trips
 }
 
+# `ddev claude-update` reports and applies Claude Code updates. Force an older version
+# into the running container to create a deterministic "update available" state, then
+# drive the command through its report (-n), update (-y), up-to-date and env-var paths.
+@test "claude-update flow" {
+  set -eu -o pipefail
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  refute_hook_failure
+
+  # Discover a real, downloadable version older than "latest" to pin as the stale
+  # starting point. There's no version-index endpoint, but each version exposes a
+  # manifest.json (200 if it exists, 404 otherwise), so walk the patch number down
+  # from latest until one resolves. This stays correct as releases come and go.
+  local base="https://downloads.claude.ai/claude-code-releases"
+  local latest_version maj min pat old_version=""
+  latest_version="$(curl -fsSL --max-time 10 "$base/latest")"
+  IFS=. read -r maj min pat <<< "${latest_version}"
+  for ((p = pat - 1; p >= 0 && p > pat - 50; p--)); do
+    if curl -fs --max-time 10 -o /dev/null "$base/${maj}.${min}.${p}/manifest.json"; then
+      old_version="${maj}.${min}.${p}"
+      break
+    fi
+  done
+  [ -n "${old_version}" ] || fail "no Claude Code version older than ${latest_version} found to test against"
+  echo "# pinning old_version=${old_version} (latest=${latest_version})" >&3
+
+  # Pin the old version. The add-on exposes claude via ~/bin, but its native updater
+  # wants ~/.local/bin on PATH, so add it here too.
+  run ddev exec 'PATH="$HOME/.local/bin:$PATH" claude install '"${old_version}"' --force'
+  assert_success
+  run ddev exec claude --version
+  assert_success
+  assert_output --partial "${old_version}"
+
+  # -n reports an update is available but must NOT change the installed version.
+  run ddev claude-update -n
+  assert_success
+  assert_output --partial "update is available"
+  assert_output --partial "${old_version}"
+  run ddev exec claude --version
+  assert_output --partial "${old_version}"
+
+  # -y applies the instant update, moving the version from the pin up to latest.
+  run ddev claude-update -y
+  assert_success
+  run ddev exec claude --version
+  assert_success
+  assert_output --partial "${latest_version}"
+
+  # Now current: -n reports up to date.
+  run ddev claude-update -n
+  assert_success
+  assert_output --partial "up to date"
+
+  # The DDEV_CLAUDE_CODE_AUTOUPDATE host env var turns a flagless run into an update.
+  # Re-pin the old version first so this genuinely exercises the update path rather
+  # than running against the now up-to-date system.
+  run ddev exec 'PATH="$HOME/.local/bin:$PATH" claude install '"${old_version}"' --force'
+  assert_success
+  run ddev exec claude --version
+  assert_output --partial "${old_version}"
+  export DDEV_CLAUDE_CODE_AUTOUPDATE=1
+  run ddev claude-update
+  unset DDEV_CLAUDE_CODE_AUTOUPDATE
+  assert_success
+  run ddev exec claude --version
+  assert_output --partial "${latest_version}"
+}
+
+# The post-start hook runs `ddev claude-update` on every start. By default it only
+# reports; with DDEV_CLAUDE_CODE_AUTOUPDATE set it applies the update. Bake an old
+# version into the image so a freshly-started container is genuinely out of date,
+# then restart with and without the env var to prove both hook behaviours.
+@test "post-start hook auto-updates when enabled" {
+  set -eu -o pipefail
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Discover a real, downloadable version older than latest (see "claude-update flow").
+  local base="https://downloads.claude.ai/claude-code-releases"
+  local latest_version maj min pat old_version=""
+  latest_version="$(curl -fsSL --max-time 10 "$base/latest")"
+  IFS=. read -r maj min pat <<< "${latest_version}"
+  for ((p = pat - 1; p >= 0 && p > pat - 50; p--)); do
+    if curl -fs --max-time 10 -o /dev/null "$base/${maj}.${min}.${p}/manifest.json"; then
+      old_version="${maj}.${min}.${p}"
+      break
+    fi
+  done
+  [ -n "${old_version}" ] || fail "no Claude Code version older than ${latest_version} found to test against"
+  echo "# baking old_version=${old_version} (latest=${latest_version})" >&3
+
+  # Pin that old version into the built image so a started container is out of date.
+  # Mirrors the add-on's own install line but targets a specific version.
+  cat >> "${TESTDIR}/.ddev/web-build/Dockerfile.claude-code" <<EOF
+RUN curl -fsSL https://claude.ai/install.sh | sudo -u \${username} bash -s -- ${old_version}
+EOF
+
+  # First start builds the old image. Without the env var the hook only reports, so
+  # the container stays on the old version (this also proves no surprise auto-update).
+  run ddev restart -y
+  assert_success
+  refute_hook_failure
+  run ddev exec claude --version
+  assert_success
+  assert_output --partial "${old_version}"
+
+  # With the env var, the post-start hook applies the update during start. The image
+  # is unchanged, so the container restarts on the old version and the hook updates it.
+  export DDEV_CLAUDE_CODE_AUTOUPDATE=1
+  run ddev restart -y
+  unset DDEV_CLAUDE_CODE_AUTOUPDATE
+  assert_success
+  refute_hook_failure
+  run ddev exec claude --version
+  assert_success
+  assert_output --partial "${latest_version}"
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail


### PR DESCRIPTION
Closes #4. Supersedes the README-only approach in #6.

## Problem

Claude Code is installed into the web image, so it's pinned to whatever version was current when the image was built. A normal `ddev restart` reuses the cached build layer, so Claude Code never updates — the cause of the stale versions reported in #4. The only way to refresh it is a slow `ddev restart --no-cache` (DDEV v1.25.0+).

## What this adds

A host command `ddev claude-update` that compares the installed version against the latest release channel and applies updates two ways, depending on how long you want them to last:

- **Instant** (`-y`): updates inside the running container in a few seconds via `claude update`. Lost on the next image rebuild.
- **Permanent**: `ddev restart --no-cache` rebuilds the image so the update sticks.

Modes:

- `-y` (or `DDEV_CLAUDE_CODE_AUTOUPDATE` set) — update now, then point at `--no-cache` to persist.
- `-n` — just report that an update is available and how to apply it.
- no flags — prompt to choose instant vs. rebuild; falls back to report-only when there's no terminal.

It also runs from a **post-start hook** (`exec-host`) on every start: report-only by default, or auto-updating when `DDEV_CLAUDE_CODE_AUTOUPDATE` is exported in the **host** shell (the command runs host-side, so a DDEV web-environment variable wouldn't be visible).

The command, both update approaches, and the env var are documented in the README.

## Tests

Two new bats tests (installing the add-on from the working directory):

- **`claude-update flow`** — drives the command through its report (`-n`), update (`-y`), up-to-date, and env-var paths.
- **`post-start hook auto-updates when enabled`** — bakes an old version into the image, then proves a default restart only reports (stays old) while an env-var restart auto-updates to latest.

Both discover a real older version dynamically (probing per-version `manifest.json`) rather than hardcoding one, so they don't rot as releases come and go. Verified passing locally against DDEV v1.25.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)