### PR TITLE
Use `env` to locate the bash binary

### DIFF
--- a/commands/host/claude-update
+++ b/commands/host/claude-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Description: Check for and optionally apply Claude Code updates

--- a/commands/web/claude
+++ b/commands/web/claude
@@ -1,5 +1,5 @@
 #ddev-generated
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Description: Claude Code!
 ## Usage: claude


### PR DESCRIPTION
## The Issue

Bash scripts assume bash is located at `/bin/bash`. I get errors from `claude-update` failing (it's run on the host).

## How This PR Solves The Issue

Use `env` to locate bash. I've also updated `commands/web/claude` which isn't currently broken because it runs inside the container, but it's still a good practice.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/FreelyGive/ddev-claude-code/tarball/refs/pull/18/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->