### PR TITLE
Stop the post-start hook prompting and hanging `ddev start`

### DIFF
--- a/commands/host/claude-update
+++ b/commands/host/claude-update
@@ -16,8 +16,8 @@ RELEASE_CHANNEL_URL="https://downloads.claude.ai/claude-code-releases/latest"
 # Parse flags:
 #   -y / DDEV_CLAUDE_CODE_AUTOUPDATE  update now, no questions asked
 #   -n                                only report whether an update exists
-#   (nothing)                         prompt; or, with no terminal (e.g. a
-#                                     post-start hook), behave like -n
+#   (nothing)                         prompt; or, with no interactive terminal,
+#                                     behave like -n
 mode="prompt"
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -28,7 +28,9 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-if [ "$mode" = "prompt" ] && [ -n "${DDEV_CLAUDE_CODE_AUTOUPDATE:-}" ]; then
+# The env var beats -n too, so the post-start hook -- which passes -n to stay
+# non-interactive -- still auto-updates for anyone who opted in.
+if [ "$mode" != "yes" ] && [ -n "${DDEV_CLAUDE_CODE_AUTOUPDATE:-}" ]; then
   mode="yes"
 fi
 
@@ -113,8 +115,10 @@ case "$mode" in
     report_only
     ;;
   prompt)
-    # No terminal (post-start hook, CI, piped): report and exit, like -n.
-    if [ ! -t 0 ]; then
+    # No interactive terminal (CI, piped, or a DDEV hook whose output we do not own):
+    # report and exit, like -n. Both ends must be a tty -- a hook can hand us a tty on
+    # stdin while capturing stdout, and prompting there hangs the start that spawned us.
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
       report_only
       exit 0
     fi

--- a/config.claude-code.yaml
+++ b/config.claude-code.yaml
@@ -6,4 +6,6 @@ hooks:
     - exec: "rm -rf ~/.claude || true; mkdir -p /var/www/html/.ddev/claude-code/.claude && ln -s /var/www/html/.ddev/claude-code/.claude ~/.claude"
     # Report (or, with DDEV_CLAUDE_CODE_AUTOUPDATE set, apply) any Claude Code update.
     # Runs on the host so it can read that env var and offer `ddev restart --no-cache`.
-    - exec-host: "ddev claude-update"
+    # -n keeps it non-interactive: prompting here would block the `ddev start` that
+    # spawned the hook, on a terminal DDEV does not own.
+    - exec-host: "ddev claude-update -n"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -186,6 +186,17 @@ teardown() {
   assert_success
   run ddev exec claude --version
   assert_output --partial "${latest_version}"
+
+  # The env var also beats an explicit -n. The post-start hook passes -n so it can
+  # never prompt, so opting into auto-updates has to keep working through that flag.
+  run ddev exec 'PATH="$HOME/.local/bin:$PATH" claude install '"${old_version}"' --force'
+  assert_success
+  export DDEV_CLAUDE_CODE_AUTOUPDATE=1
+  run ddev claude-update -n
+  unset DDEV_CLAUDE_CODE_AUTOUPDATE
+  assert_success
+  run ddev exec claude --version
+  assert_output --partial "${latest_version}"
 }
 
 # The post-start hook runs `ddev claude-update` on every start. By default it only


### PR DESCRIPTION
Fixes #21.

From claude:

The README says the post-start hook runs `ddev claude-update` in report-only mode, but the hook passed no flags and the command's "am I interactive?" guard was only `[ -t 0 ]`. Inside a DDEV `exec-host` hook stdin is still a tty, so the guard passed and the command printed its `[i/p/c]` menu and blocked on `read` -- freezing the `ddev start` that spawned it (and, when the start was triggered implicitly, the `ddev claude` behind it). Answering did not free it: `[i]` shells out to a nested `ddev exec` and `[p]` `exec`s `ddev restart --no-cache`, both from inside a start still in progress.

CI never caught it because bats runs with stdin on a pipe, where the old guard happened to do the right thing.

- Pass `-n` in the hook so the documented report-only behaviour is what the hook actually asks for, rather than a side effect of tty detection.
- Require a tty on stdout as well as stdin before prompting, so any other caller that captures our output degrades to a report instead of hanging.
- Let DDEV_CLAUDE_CODE_AUTOUPDATE override `-n`, so opting into auto-updates still works now that the hook passes that flag.
- Cover the env-var-beats-`-n` path in tests/test.bats.


## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/FreelyGive/ddev-claude-code/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->